### PR TITLE
Column Width Properties for new Metadata

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -43,5 +43,8 @@
 		
 		<!-- OpenML API -->
 		<dependency org="org.openml" name="apiconnector" rev="1.0.4"/>
+		
+		<!-- Apache Commons Math -->
+		<dependency org="org.apache.commons" name="commons-math3" rev="3.4.1"/>
 	</dependencies>
 </ivy-module>

--- a/ivy.xml
+++ b/ivy.xml
@@ -41,5 +41,7 @@
 		<dependency org="com.jcraft" name="jsch" rev="0.1.50" />
 		<dependency org="org.fusesource.jansi" name="jansi" rev="1.11" />
 		
+		<!-- OpenML API -->
+		<dependency org="org.openml" name="apiconnector" rev="1.0.4"/>
 	</dependencies>
 </ivy-module>

--- a/src/org/pikater/web/vaadin/gui/server/components/dbviews/CategoricalMetadataDBViewRoot.java
+++ b/src/org/pikater/web/vaadin/gui/server/components/dbviews/CategoricalMetadataDBViewRoot.java
@@ -32,15 +32,21 @@ public class CategoricalMetadataDBViewRoot extends AbstractDBViewRoot<Categorica
 		case RATIO_OF_MISSING_VALUES:
 			return 125;
 		case CLASS_ENTROPY:
-			return 75;
+			return 45;
 		case ENTROPY:
-			return 115;
+			return 45;
 		case CHI_SQUARE:
 			return 45;
 		case CHI_SQUARE_TEST:
 			return 45;
 		case G_TEST:
 			return 45;
+		case COVARIANCE:
+		case U_TEST:
+		case KS_TEST:
+		case ANOVA:
+			return 45;
+
 		default:
 			throw new IllegalStateException(String.format("No sizing information found for column '%s'", specificColumn.name()));
 		}

--- a/src/org/pikater/web/vaadin/gui/server/components/dbviews/CategoricalMetadataDBViewRoot.java
+++ b/src/org/pikater/web/vaadin/gui/server/components/dbviews/CategoricalMetadataDBViewRoot.java
@@ -35,6 +35,12 @@ public class CategoricalMetadataDBViewRoot extends AbstractDBViewRoot<Categorica
 			return 75;
 		case ENTROPY:
 			return 115;
+		case CHI_SQAURE:
+			return 45;
+		case CHI_SQUARE_TEST:
+			return 45;
+		case G_TEST:
+			return 45;
 		default:
 			throw new IllegalStateException(String.format("No sizing information found for column '%s'", specificColumn.name()));
 		}

--- a/src/org/pikater/web/vaadin/gui/server/components/dbviews/CategoricalMetadataDBViewRoot.java
+++ b/src/org/pikater/web/vaadin/gui/server/components/dbviews/CategoricalMetadataDBViewRoot.java
@@ -35,7 +35,7 @@ public class CategoricalMetadataDBViewRoot extends AbstractDBViewRoot<Categorica
 			return 75;
 		case ENTROPY:
 			return 115;
-		case CHI_SQAURE:
+		case CHI_SQUARE:
 			return 45;
 		case CHI_SQUARE_TEST:
 			return 45;

--- a/src/org/pikater/web/vaadin/gui/server/components/dbviews/NumericalMetadataDBViewRoot.java
+++ b/src/org/pikater/web/vaadin/gui/server/components/dbviews/NumericalMetadataDBViewRoot.java
@@ -27,7 +27,7 @@ public class NumericalMetadataDBViewRoot extends AbstractDBViewRoot<NumericalMet
 			return 100;
 		case IS_TARGET:
 		case IS_REAL:
-			return 50;
+			return 25;
 
 		case MINIMUM:
 		case MAXIMUM:
@@ -38,21 +38,26 @@ public class NumericalMetadataDBViewRoot extends AbstractDBViewRoot<NumericalMet
 		// case MODE:
 		case CHI_SQUARE_NORM:
 		case CHI_SQUARE_NORM_T:
+			return 35;
 		case G_TEST:
 			return 45;
 		case QUARTILE_1:
 		case QUARTILE_2:
 		case QUARTILE_3:
-			return 65;
+			return 25;
 		case STD_DEVIATION:
 		case VARIANCE:
-			return 45;
+			return 25;
 		case RATIO_OF_MISSING_VALUES:
-			return 55;
+			return 25;
 		case ENTROPY:
-			return 70;
+			return 30;
 		case CLASS_ENTROPY:
-			return 80;
+			return 30;
+		case COVARIANCE:
+		case U_TEST:
+		case KS_TEST:
+			return 35;
 
 		default:
 			throw new IllegalStateException(String.format("No sizing information found for column '%s'", specificColumn.name()));

--- a/src/org/pikater/web/vaadin/gui/server/components/dbviews/NumericalMetadataDBViewRoot.java
+++ b/src/org/pikater/web/vaadin/gui/server/components/dbviews/NumericalMetadataDBViewRoot.java
@@ -36,8 +36,11 @@ public class NumericalMetadataDBViewRoot extends AbstractDBViewRoot<NumericalMet
 		case AVERAGE:
 		case MEDIAN:
 		// case MODE:
+		case QUARTILE_1:
+		case QUARTILE_2:
+		case QUARTILE_3:
 			return 65;
-
+		case STD_DEVIATION:
 		case VARIANCE:
 			return 70;
 		case RATIO_OF_MISSING_VALUES:

--- a/src/org/pikater/web/vaadin/gui/server/components/dbviews/NumericalMetadataDBViewRoot.java
+++ b/src/org/pikater/web/vaadin/gui/server/components/dbviews/NumericalMetadataDBViewRoot.java
@@ -26,29 +26,31 @@ public class NumericalMetadataDBViewRoot extends AbstractDBViewRoot<NumericalMet
 		case NAME:
 			return 100;
 		case IS_TARGET:
-			return 75;
-
 		case IS_REAL:
-			return 55;
+			return 50;
 
 		case MINIMUM:
 		case MAXIMUM:
 		case AVERAGE:
 		case MEDIAN:
 		// case MODE:
+		case CHI_SQUARE_NORM:
+		case CHI_SQUARE_NORM_T:
+		case G_TEST:
+			return 45;
 		case QUARTILE_1:
 		case QUARTILE_2:
 		case QUARTILE_3:
 			return 65;
 		case STD_DEVIATION:
 		case VARIANCE:
-			return 70;
+			return 45;
 		case RATIO_OF_MISSING_VALUES:
-			return 125;
+			return 55;
 		case ENTROPY:
 			return 70;
 		case CLASS_ENTROPY:
-			return 100;
+			return 80;
 
 		default:
 			throw new IllegalStateException(String.format("No sizing information found for column '%s'", specificColumn.name()));

--- a/src/org/pikater/web/vaadin/gui/server/components/dbviews/NumericalMetadataDBViewRoot.java
+++ b/src/org/pikater/web/vaadin/gui/server/components/dbviews/NumericalMetadataDBViewRoot.java
@@ -33,6 +33,8 @@ public class NumericalMetadataDBViewRoot extends AbstractDBViewRoot<NumericalMet
 		case MAXIMUM:
 		case AVERAGE:
 		case MEDIAN:
+		case SKEWNESS:
+		case KURTOSIS:
 		// case MODE:
 		case CHI_SQUARE_NORM:
 		case CHI_SQUARE_NORM_T:


### PR DESCRIPTION
We have added some new metadata to datasets and we had to add width definitions for columns of these new attributes.

Additional minor changes happened in ivy.xml, where we added openml and apache-maths libraries, which are from now used in core.